### PR TITLE
add a 1m read/write buffer on disk io

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Deps._
 
 name := "featury"
 
-lazy val featuryVersion = "0.1.3-M1-SNAPSHOT"
+lazy val featuryVersion = "0.1.3-M2-SNAPSHOT"
 
 version := featuryVersion
 

--- a/flink/src/main/scala/io/findify/featury/flink/rw/CompressedBulkReader.scala
+++ b/flink/src/main/scala/io/findify/featury/flink/rw/CompressedBulkReader.scala
@@ -8,9 +8,11 @@ import org.apache.flink.connector.file.src.reader.StreamFormat
 import org.apache.flink.core.fs.{FSDataInputStream, Path}
 import scalapb.GeneratedMessage
 
-import java.io.InputStream
+import java.io.{BufferedInputStream, InputStream}
 
 object CompressedBulkReader {
+  val READ_BUFFER_SIZE = 1024 * 1024
+
   def readFile[T >: Null](path: Path, compress: Compress, codec: BulkCodec[T])(implicit ti: TypeInformation[T]) = {
     FileSource.forRecordStreamFormat[T](CompressedStreamFormat(ti, compress, codec), path).build()
   }
@@ -33,7 +35,7 @@ object CompressedBulkReader {
         fileLen: Long,
         splitEnd: Long
     ): StreamFormat.Reader[T] = {
-      val compStream = compress.read(stream)
+      val compStream = new BufferedInputStream(compress.read(stream), READ_BUFFER_SIZE)
       compStream.skip(restoredOffset)
       CompressedStreamFormatReader(compStream, codec)
     }

--- a/flink/src/main/scala/io/findify/featury/flink/rw/CompressedBulkWriter.scala
+++ b/flink/src/main/scala/io/findify/featury/flink/rw/CompressedBulkWriter.scala
@@ -12,6 +12,8 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.
 import java.io.BufferedOutputStream
 
 object CompressedBulkWriter {
+  val WRITE_BUFFER_SIZE = 1024 * 1024
+
   def writeFile[T](
       path: Path,
       compress: Compress,
@@ -35,7 +37,9 @@ object CompressedBulkWriter {
       override def finish(): Unit               = out.close()
     }
     override def create(out: FSDataOutputStream): BulkWriter[T] =
-      new CompressedBulkWriter(new BufferedOutputStream(compress.write(new NoCloseOutputStream(out)), 10 * 1024))
+      new CompressedBulkWriter(
+        new BufferedOutputStream(compress.write(new NoCloseOutputStream(out)), WRITE_BUFFER_SIZE)
+      )
   }
 
   case class SimpleBucketAssigner[T](codec: BulkCodec[T]) extends BucketAssigner[T, String] {


### PR DESCRIPTION
As otherwise we stuck on a too small read-write compression buffers:
![image](https://user-images.githubusercontent.com/999061/129353465-53f2fd92-422d-4a2f-a378-238abf4289ae.png)

Almost 40% of time is spent on ZSTD compression, which should be almost instant.