### PR TITLE
add inmem connector compatible with flink sink

### DIFF
--- a/api/src/main/scala/io/findify/featury/api/MetricsApi.scala
+++ b/api/src/main/scala/io/findify/featury/api/MetricsApi.scala
@@ -6,7 +6,6 @@ import io.findify.featury.model._
 import io.prometheus.client.{CollectorRegistry, Counter, Gauge, Histogram, Summary}
 import io.prometheus.client.exporter.common.TextFormat
 import org.http4s.HttpRoutes
-import org.http4s.Uri.Path.Segment
 import org.http4s.dsl.io._
 
 import java.io.{ByteArrayOutputStream, OutputStreamWriter}

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Deps._
 
 name := "featury"
 
-lazy val featuryVersion = "0.2.1"
+lazy val featuryVersion = "0.3.0-M2"
 
 version := featuryVersion
 
@@ -29,7 +29,7 @@ lazy val mavenSettings = Seq(
   )
 )
 
-scalaVersion := "2.12.14"
+scalaVersion := "2.12.15"
 
 lazy val core = (project in file("core")).settings(shared: _*).settings(mavenSettings: _*)
 
@@ -37,6 +37,7 @@ lazy val flink = (project in file("flink"))
   .settings(shared: _*)
   .settings(mavenSettings: _*)
   .dependsOn(core % "test->test;compile->compile")
+  .dependsOn(rocksdb % "test->test;compile->compile")
 
 lazy val examples = (project in file("examples"))
   .settings(shared: _*)
@@ -65,6 +66,12 @@ lazy val rocksdb = (project in file("connector/rocksdb"))
   .settings(shared: _*)
   .settings(mavenSettings: _*)
   .dependsOn(core % "test->test;compile->compile")
+
+lazy val memory = (project in file("connector/memory"))
+  .settings(shared: _*)
+  .settings(mavenSettings: _*)
+  .dependsOn(core % "test->test;compile->compile")
+  .dependsOn(redis % "test->test;compile->compile")
 
 lazy val root = (project in file("."))
   .aggregate(core, flink, api, redis, cassandra, rocksdb, examples)

--- a/connector/memory/build.sbt
+++ b/connector/memory/build.sbt
@@ -1,0 +1,7 @@
+import Deps._
+
+name := "featury-memory"
+
+libraryDependencies ++= Seq(
+  "com.github.microwww" % "redis-server" % "0.2.2"
+)

--- a/connector/memory/src/main/scala/io/findify/featury/connector/memory/OffheapMemoryStore.scala
+++ b/connector/memory/src/main/scala/io/findify/featury/connector/memory/OffheapMemoryStore.scala
@@ -1,0 +1,33 @@
+package io.findify.featury.connector.memory
+
+import cats.effect
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import com.github.microwww.redis.RedisServer
+import io.findify.featury.values.StoreCodec.ProtobufCodec
+import io.findify.featury.values.ValueStoreConfig.RedisConfig
+
+case class OffheapMemoryStore(handle: RedisServer) {
+  def config: RedisConfig = RedisConfig(
+    host = "localhost",
+    port = handle.getSockets.getServerSocket.getLocalPort,
+    codec = ProtobufCodec
+  )
+}
+
+object OffheapMemoryStore {
+
+  def start(port: Int): Resource[IO, OffheapMemoryStore] =
+    effect.Resource.make(IO(startUnsafe(port)))(mem => IO(stopUnsafe(mem)))
+
+  def startUnsafe(port: Int) = {
+    val server = new RedisServer()
+    server.listener("127.0.0.1", port)
+    server.getSchema // hack for https://github.com/microwww/redis-mock/pull/6
+    OffheapMemoryStore(server)
+  }
+
+  def stopUnsafe(store: OffheapMemoryStore) = {
+    store.handle.close()
+  }
+}

--- a/connector/memory/src/test/scala/io/findify/featury/connector/memory/OffheapMemoryStoreTest.scala
+++ b/connector/memory/src/test/scala/io/findify/featury/connector/memory/OffheapMemoryStoreTest.scala
@@ -1,0 +1,35 @@
+package io.findify.featury.connector.memory
+
+import cats.effect.{IO, Resource}
+import io.findify.featury.StoreTestSuite
+import io.findify.featury.connector.redis.RedisStore
+import io.findify.featury.values.StoreCodec.ProtobufCodec
+import io.findify.featury.values.ValueStoreConfig.RedisConfig
+import redis.clients.jedis.args.FlushMode
+
+import scala.util.Random
+
+class OffheapMemoryStoreTest extends StoreTestSuite[RedisStore] {
+  var server: OffheapMemoryStore = _
+  override def beforeAll = {
+    super.beforeAll()
+    server = OffheapMemoryStore.startUnsafe(16379)
+    val jedis = store.clientPool.pool.getResource
+    jedis.flushAll(FlushMode.SYNC)
+    store.clientPool.pool.returnResource(jedis)
+  }
+
+  override def afterAll(): Unit = {
+    OffheapMemoryStore.stopUnsafe(server)
+    super.afterAll()
+  }
+  override def storeResource =
+    Resource.make(IO {
+      RedisStore(RedisConfig("localhost", 16379, ProtobufCodec))
+    })(redis => IO(redis.close()))
+
+  it should "start and stop server" in {
+    val server = OffheapMemoryStore.startUnsafe(1024 + Random.nextInt(50000))
+    OffheapMemoryStore.stopUnsafe(server)
+  }
+}

--- a/connector/rocksdb/build.sbt
+++ b/connector/rocksdb/build.sbt
@@ -3,5 +3,5 @@ import Deps._
 name := "featury-rocksdb"
 
 libraryDependencies ++= Seq(
-  "com.data-artisans" % "frocksdbjni" % "5.17.2-artisans-2.0"
+  "com.ververica" % "frocksdbjni" % "6.20.3-ververica-1.0"
 )

--- a/connector/rocksdb/src/test/scala/io/findify/featury/connector/rocksdb/RocksDBStoreTest.scala
+++ b/connector/rocksdb/src/test/scala/io/findify/featury/connector/rocksdb/RocksDBStoreTest.scala
@@ -9,5 +9,5 @@ import io.findify.featury.values.StoreCodec.ProtobufCodec
 class RocksDBStoreTest extends StoreTestSuite[RocksDBStore] {
   lazy val path = File.newTemporaryDirectory("rocksdb_").deleteOnExit()
   override def storeResource =
-    Resource.make(IO(RocksDBStore(path.toString(), ProtobufCodec)))(x => IO(x.close()))
+    Resource.make(IO(RocksDBStore(path.toString(), ProtobufCodec, false)))(x => IO(x.close()))
 }

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   "io.circe"              %% "circe-generic-extras" % circeVersion,
   "io.circe"              %% "circe-parser"         % circeVersion,
   "org.typelevel"         %% "cats-effect"          % "3.2.9",
-  "com.github.pureconfig" %% "pureconfig"           % "0.16.0",
+  "com.github.pureconfig" %% "pureconfig"           % "0.17.0",
   "org.typelevel"         %% "log4cats-core"        % log4catsVersion,
   "org.typelevel"         %% "log4cats-slf4j"       % log4catsVersion,
   "com.github.blemale"    %% "scaffeine"            % "5.1.1"

--- a/core/src/main/scala/io/findify/featury/values/ValueStoreConfig.scala
+++ b/core/src/main/scala/io/findify/featury/values/ValueStoreConfig.scala
@@ -31,6 +31,7 @@ object ValueStoreConfig {
   implicit val redisDecoder: Decoder[RedisConfig]         = deriveDecoder
   implicit val memDecoder: Decoder[MemoryConfig]          = deriveDecoder
   implicit val cassandraDecoder: Decoder[CassandraConfig] = deriveDecoder
+
   implicit val config = Configuration.default
     .withDiscriminator("type")
     .copy(transformConstructorNames = {

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -12,19 +12,4 @@
     <logger name="io.netty" level="INFO"/>
     <logger name="com.datastax.oss.driver" level="INFO"/>
     <logger name="org.apache.flink" level="INFO"/>
-    <root level="error">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="Sentry"/>
-    </root>
-    <root level="warn">
-        <appender-ref ref="STDOUT"/>
-    </root>
-    <root level="info">
-        <appender-ref ref="STDOUT"/>
-    </root>
-
-    <root level="debug">
-        <appender-ref ref="STDOUT"/>
-    </root>
-
 </configuration>

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -1,12 +1,12 @@
 object Deps {
-  val http4sVersion          = "1.0.0-M27"
+  val http4sVersion          = "1.0.0-M29"
   val log4catsVersion        = "2.1.1"
   val scalatestVersion       = "3.2.10"
   val circeVersion           = "0.14.1"
   val circeYamlVersion       = "0.14.1"
   val cassandraDriverVersion = "4.13.0"
-  val scalapbVersion         = "0.11.5"
-  val flinkVersion           = "1.13.2"
+  val scalapbVersion         = "0.11.6"
+  val flinkVersion           = "1.14.0"
   val logbackVersion         = "1.2.6"
   val prometheusVersion      = "0.12.0"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.5"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.6"
 
 addSbtPlugin("com.thesamet"     % "sbt-protoc"           % "1.0.3")
 addSbtPlugin("org.jetbrains"    % "sbt-ide-settings"     % "1.1.0")


### PR DESCRIPTION
So it actually wraps an instance of https://github.com/microwww/redis-mock and uses redis from multiple flink threads (if we have parallelism > 1) to access the state. Seems hacky, but should work fine for local runs.